### PR TITLE
Fix bug with GC and function lifetime in the cache

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -80,3 +80,11 @@ using RGFPrecompTest
 
 @test RGFPrecompTest.f(1,2) == 3
 
+# Test that RuntimeGeneratedFunction with identical body expressions (but
+# allocated separately) don't clobber each other when one is GC'd.
+f_gc = @RuntimeGeneratedFunction(Base.remove_linenums!(:((x,y)->x+y+100001)))
+let
+    @RuntimeGeneratedFunction(Base.remove_linenums!(:((x,y)->x+y+100001)))
+end
+GC.gc()
+@test f_gc(1,-1) == 100001


### PR DESCRIPTION
Functions with bodies which share identical syntax collide in the cache.
The cache needs to be carefully managed to ensure this isn't a problem.

In particular, if a cache entry already exists for a given `id`, we need
to use that as the body rather than the body we have. But only if it
wasn't previously collected.