### PR TITLE
Add global lock around the caching mechanism

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -88,3 +88,22 @@ let
 end
 GC.gc()
 @test f_gc(1,-1) == 100001
+
+# Test that threaded use works
+tasks = []
+for k=1:4
+    let k=k
+        t = Threads.@spawn begin
+            r = Bool[]
+            for i=1:100
+                f = @RuntimeGeneratedFunction(Base.remove_linenums!(:((x,y)->x+y+$i*$k)))
+                x = 1; y = 2;
+                push!(r, f(x,y) == x + y + i*k)
+            end
+            r
+        end
+        push!(tasks, t)
+    end
+end
+@test all(all.(fetch.(tasks)))
+


### PR DESCRIPTION
Should fix #8

I had some confusing deadlocks trying out `ReentrantLock`, so I opted to use `SpinLock` here. Generally that's not advisable, but I think the inside of the locked regions here should be minimal enough that it's safe.

As to the cause of the deadlock, I don't really know what that's about. Perhaps it's causing us to accidentally task switch when running the `@generated` function body... I could imagine that interacting badly with the compiler somehow.