### PR TITLE
Shorter stacktrace

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RuntimeGeneratedFunctions"
 uuid = "7e49a35a-f44a-4d26-94aa-eba1b4ca6b47"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"

--- a/src/RuntimeGeneratedFunctions.jl
+++ b/src/RuntimeGeneratedFunctions.jl
@@ -21,6 +21,15 @@ struct RuntimeGeneratedFunction{moduletag,id,argnames}
     end
 end
 
+function Base.show(io::IO, ::Type{<:RuntimeGeneratedFunction{mod,id,arg}}) where {mod,id,arg}
+    print(io, "RuntimeGeneratedFunction{$arg}")
+end
+
+# don't override typeof
+function Base.show(io::IO, ::MIME"text/plain", ::Type{<:RuntimeGeneratedFunction{mod,id,arg}}) where {mod,id,arg}
+    print(io, "RuntimeGeneratedFunction{$mod, $id, $arg}")
+end
+
 """
     @RuntimeGeneratedFunction(function_expression)
 


### PR DESCRIPTION
Now the stacktrace looks like this instead of the whole type printing with
bytes.
```julia
julia> f1(du,u,p,t)
ERROR:
Stacktrace:
 [1] error() at ./error.jl:42
 [2] macro expansion at ./REPL[36]:2 [inlined]
 [3] macro expansion at /Users/scheme/.julia/packages/RuntimeGeneratedFunctions/fIcZp/src/RuntimeGeneratedFunctions.jl:80 [inlined]
 [4] macro expansion at ./none:0 [inlined]
 [5] generated_callfunc at ./none:0 [inlined]
 [6] (::RuntimeGeneratedFunction{(:_du, :_u, :_p, :_t)})(::Array{Float64,1}, ::Array{Float64,1}, ::Nothing, ::Nothing) at /Users/scheme/.julia/dev/RuntimeGeneratedFunctions/src/RuntimeGeneratedFunctions.jl:77
 [7] top-level scope at REPL[42]:1

julia> typeof(f1)
RuntimeGeneratedFunction{var"#_RuntimeGeneratedFunctions_ModTag", (0x47, 0x4a, 0x02, 0xf7, 0xc0, 0xd0, 0xdf, 0x8d, 0x8c, 0xac, 0x18, 0x52, 0x0f, 0x01, 0xbf, 0x94, 0xc0, 0xf6, 0xf1, 0x73, 0x89, 0x1b, 0xe5, 0x1d, 0x94, 0x75, 0xa9, 0xbf, 0x06, 0xa0, 0x96, 0xd5, 0xbb, 0xd3, 0xfa, 0x0d, 0xfd, 0xb4, 0x1f, 0xec, 0xfd, 0xb3, 0x6a, 0x05, 0x53, 0x92, 0x3a, 0x59, 0x0e, 0x35, 0x51, 0x05, 0xe8, 0xd4, 0x28, 0xec, 0x95, 0x97, 0x9b, 0x78, 0xe0, 0x1b, 0xc9, 0x9c), (:_du, :_u, :_p, :_t)}
```