### PR TITLE
Simplify RuntimeGeneratedFunction type printing, but don't lie about the type :-)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RuntimeGeneratedFunctions"
 uuid = "7e49a35a-f44a-4d26-94aa-eba1b4ca6b47"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "0.4.1"
+version = "0.4.0"
 
 [deps]
 ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"

--- a/src/RuntimeGeneratedFunctions.jl
+++ b/src/RuntimeGeneratedFunctions.jl
@@ -10,7 +10,7 @@ export @RuntimeGeneratedFunction
 
 This type should be constructed via the macro @RuntimeGeneratedFunction.
 """
-struct RuntimeGeneratedFunction{argnames,moduletag,id}
+struct RuntimeGeneratedFunction{argnames,moduletag,id} <: Function
     body::Expr
     function RuntimeGeneratedFunction(moduletag, ex)
         def = splitdef(ex)

--- a/src/RuntimeGeneratedFunctions.jl
+++ b/src/RuntimeGeneratedFunctions.jl
@@ -21,15 +21,6 @@ struct RuntimeGeneratedFunction{moduletag,id,argnames}
     end
 end
 
-function Base.show(io::IO, ::Type{<:RuntimeGeneratedFunction{mod,id,arg}}) where {mod,id,arg}
-    print(io, "RuntimeGeneratedFunction{$arg}")
-end
-
-# don't override typeof
-function Base.show(io::IO, ::MIME"text/plain", ::Type{<:RuntimeGeneratedFunction{mod,id,arg}}) where {mod,id,arg}
-    print(io, "RuntimeGeneratedFunction{$mod, $id, $arg}")
-end
-
 """
     @RuntimeGeneratedFunction(function_expression)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,6 +31,8 @@ f1 = @RuntimeGeneratedFunction(ex1)
 f2 = @RuntimeGeneratedFunction(ex2)
 f3 = @RuntimeGeneratedFunction(ex3)
 
+@test f1 isa Function
+
 du = rand(2)
 u = rand(2)
 p = nothing


### PR DESCRIPTION
Alas this is not nearly as pretty as #15, but overloading `show(::IO, ::Type{SomeType})` has been known to cause subtle problems in the past. And suspected of causing them quite recently, though I'm not sure it was conclusively proven.

So instead, here I've tried to shorten the RuntimeGeneratedFunction type:

- Use SHA1 and use UInt32's to encode the 20 bits. sha1 has been good enough for git, and 64 bytes for sha512 is an awful lot.
- Reorder the RuntimeGeneratedFunction type parameters to make them easier to read.
- Shorten the module tag name

For example:

```julia
julia> typeof(@RuntimeGeneratedFunction(:((x,)->x+1)))
RuntimeGeneratedFunctions.RuntimeGeneratedFunction{(:x,),var"#_RGF_ModTag",(0x191f585f, 0xfaf6f6de, 0xca63d6a8, 0x0d1317a1, 0x08ebef57)}
```

Which is hardly pretty, but not as bad as before.