### PR TITLE
Allow cache module to be given in RGF constructor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RuntimeGeneratedFunctions"
 uuid = "7e49a35a-f44a-4d26-94aa-eba1b4ca6b47"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "0.5.0"
+version = "0.5.1"
 
 [deps]
 ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"

--- a/test/precomp/RGFPrecompTest.jl
+++ b/test/precomp/RGFPrecompTest.jl
@@ -1,6 +1,9 @@
 module RGFPrecompTest
     using RuntimeGeneratedFunctions
+    using RGFPrecompTest2
     RuntimeGeneratedFunctions.init(@__MODULE__)
 
     f = @RuntimeGeneratedFunction(:((x,y)->x+y))
+
+    g = RGFPrecompTest2.generate_rgf(@__MODULE__)
 end

--- a/test/precomp/RGFPrecompTest2.jl
+++ b/test/precomp/RGFPrecompTest2.jl
@@ -1,0 +1,13 @@
+module RGFPrecompTest2
+    using RuntimeGeneratedFunctions
+    RuntimeGeneratedFunctions.init(@__MODULE__)
+
+    y_in_RGFPrecompTest2 = 2
+
+    # Simulates a helper function which generates an RGF, but caches it in a
+    # different module.
+    function generate_rgf(cache_module)
+        context_module = @__MODULE__
+        RuntimeGeneratedFunction(cache_module, @__MODULE__, :((x)->y_in_RGFPrecompTest2+x))
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -83,6 +83,7 @@ push!(LOAD_PATH, joinpath(@__DIR__, "precomp"))
 using RGFPrecompTest
 
 @test RGFPrecompTest.f(1,2) == 3
+@test RGFPrecompTest.g(40) == 42
 
 # Test that RuntimeGeneratedFunction with identical body expressions (but
 # allocated separately) don't clobber each other when one is GC'd.


### PR DESCRIPTION
This exposes the full constructor (without the need for specifying
module tags), as we seem to need this for utility functions which want
to cache the RGF in a user-specified module.

Looks like this is needed to make https://github.com/SciML/ModelingToolkit.jl/pull/769 less hacky.