### PR TITLE
Ensure RGF body is added to the cache when deserializing

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using RuntimeGeneratedFunctions, BenchmarkTools
+using Serialization
 using Test
 
 RuntimeGeneratedFunctions.init(@__MODULE__)
@@ -158,3 +159,9 @@ if VERSION >= v"1.7.0-DEV.351"
     ex = :(x -> [2i for i in 1:x])
     @test @RuntimeGeneratedFunction(ex)(3) == [2, 4, 6]
 end
+
+# Serialization
+
+buf = IOBuffer(read(`$(Base.julia_cmd()) "serialize_rgf.jl"`))
+deserialized_f = deserialize(buf)
+@test deserialized_f(11) == "Hi from a separate process. x=11"

--- a/test/serialize_rgf.jl
+++ b/test/serialize_rgf.jl
@@ -1,0 +1,10 @@
+# Must be run in a separate process from the rest of the tests!
+
+using RuntimeGeneratedFunctions
+using Serialization
+
+RuntimeGeneratedFunctions.init(@__MODULE__)
+
+f = @RuntimeGeneratedFunction(:(x->"Hi from a separate process. x=$x"))
+
+serialize(stdout, f)


### PR DESCRIPTION
This allows for:

* RGFs to be used with Distributed.jl
* RGFs to be read back from other uses of Julia's serialization format.