### PR TITLE
Re-enable GC of RGFs which haven't been `drop_expr()`d

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -96,6 +96,17 @@ end
 GC.gc()
 @test f_gc(1, -1) == 100001
 
+# Test that drop_expr works
+f_drop1, f_drop2 = let
+    ex = Base.remove_linenums!(:(x -> x - 1))
+    # Construct two identical RGFs here to test the cache deduplication code
+    (drop_expr(@RuntimeGeneratedFunction(ex)),
+     drop_expr(@RuntimeGeneratedFunction(ex)))
+end
+GC.gc()
+@test f_drop1(1) == 0
+@test f_drop2(1) == 0
+
 # Test that threaded use works
 tasks = []
 for k in 1:4


### PR DESCRIPTION
Revert some of https://github.com/SciML/RuntimeGeneratedFunctions.jl/pull/62

Originally GC of RGFs was implemented because people seemed to need it.  So dropping support for this completely doesn't seem great.

Instead, this PR lets normal RGF bodies be GC'd as always.  But if one calls `drop_expr`, we upgrade the `WeakRef` to a normal strong reference in the cache, preventing the body from being GC'd thereafter.