### PR TITLE
try fixing opaque_closure generation on 1.12

### DIFF
--- a/src/RuntimeGeneratedFunctions.jl
+++ b/src/RuntimeGeneratedFunctions.jl
@@ -55,7 +55,9 @@ struct RuntimeGeneratedFunction{argnames, cache_tag, context_tag, id, B} <: Func
         def = splitdef(ex)
         args = normalize_args(get(def, :args, Symbol[]))
         body = def[:body]
-        body = closures_to_opaque(body)
+        if opaque_closures
+            body = closures_to_opaque(body)
+        end
         id = expr_to_id(body)
         cached_body = _cache_body(cache_tag, id, body)
         new{Tuple(args), cache_tag, context_tag, id, typeof(cached_body)}(cached_body)

--- a/src/RuntimeGeneratedFunctions.jl
+++ b/src/RuntimeGeneratedFunctions.jl
@@ -1,6 +1,7 @@
 module RuntimeGeneratedFunctions
 
 using ExprTools, Serialization, SHA
+import Base.Experimental: @opaque
 
 export RuntimeGeneratedFunction, @RuntimeGeneratedFunction, drop_expr
 
@@ -34,9 +35,7 @@ If `opaque_closures` is `true`, all closures in `function_expression` are
 converted to
 [opaque closures](https://github.com/JuliaLang/julia/pull/37849#issue-496641229).
 This allows for the use of closures and generators inside the generated function,
-but may not work in all cases due to slightly different semantics. This feature
-requires Julia 1.7.
-
+but may not work in all cases due to slightly different semantics.
 # Examples
 ```
 RuntimeGeneratedFunctions.init(@__MODULE__) # Required at module top-level
@@ -56,10 +55,7 @@ struct RuntimeGeneratedFunction{argnames, cache_tag, context_tag, id, B} <: Func
         def = splitdef(ex)
         args = normalize_args(get(def, :args, Symbol[]))
         body = def[:body]
-        if opaque_closures && isdefined(Base, :Experimental) &&
-           isdefined(Base.Experimental, Symbol("@opaque"))
-            body = closures_to_opaque(body)
-        end
+        body = closures_to_opaque(body)
         id = expr_to_id(body)
         cached_body = _cache_body(cache_tag, id, body)
         new{Tuple(args), cache_tag, context_tag, id, typeof(cached_body)}(cached_body)
@@ -306,7 +302,8 @@ function closures_to_opaque(ex::Expr, return_type = nothing)
         fdef[:body] = body
         name = get(fdef, :name, nothing)
         name !== nothing && delete!(fdef, :name)
-        _ex = Expr(:macrocall, Symbol("@opaque"), LineNumberNode(0), combinedef(fdef))
+        opaque = Expr(:., Expr(:., :Base, QuoteNode(:Experimental)), QuoteNode(Symbol("@opaque")))
+        _ex = Expr(:macrocall, opaque, LineNumberNode(0), combinedef(fdef))
         # TODO: emit named opaque closure for better stacktraces
         # (ref https://github.com/JuliaLang/julia/pull/40242)
         if name !== nothing

--- a/src/RuntimeGeneratedFunctions.jl
+++ b/src/RuntimeGeneratedFunctions.jl
@@ -306,7 +306,7 @@ function closures_to_opaque(ex::Expr, return_type = nothing)
         fdef[:body] = body
         name = get(fdef, :name, nothing)
         name !== nothing && delete!(fdef, :name)
-        _ex = Expr(:opaque_closure, combinedef(fdef))
+        _ex = Expr(:macrocall, Symbol("@opaque"), LineNumberNode(0), combinedef(fdef))
         # TODO: emit named opaque closure for better stacktraces
         # (ref https://github.com/JuliaLang/julia/pull/40242)
         if name !== nothing


### PR DESCRIPTION
As suggested by @JeffBezanson

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
