### PR TITLE
don't copy RGF on deepcopy

### DIFF
--- a/src/RuntimeGeneratedFunctions.jl
+++ b/src/RuntimeGeneratedFunctions.jl
@@ -376,6 +376,9 @@ function Serialization.deserialize(s::AbstractSerializer,
     B === Nothing ? drop_expr(f) : f
 end
 
+# achieve deepcopy(f)===f behavior similar to "normal" julia functions
+Base.deepcopy_internal(f::RuntimeGeneratedFunction, stackdict::IdDict) = f
+
 @specialize
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -187,5 +187,5 @@ deserialized_f, deserialized_g = deserialize(buf)
 
 # deepcopy
 ff = @RuntimeGeneratedFunction(:(x -> [x, x+1]))
-@test deepcopy(f) == ff
-@test deepcopy(f) === ff
+@test deepcopy(ff) == ff
+@test deepcopy(ff) === ff

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -186,6 +186,6 @@ deserialized_f, deserialized_g = deserialize(buf)
 @test deserialized_g.body isa Nothing
 
 # deepcopy
-f = @RuntimeGeneratedFunction(:(x -> [x, x+1]))
-@test deepcopy(f) == f
-@test deepcopy(f) === f
+ff = @RuntimeGeneratedFunction(:(x -> [x, x+1]))
+@test deepcopy(f) == ff
+@test deepcopy(f) === ff

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -184,3 +184,8 @@ deserialized_f, deserialized_g = deserialize(buf)
 @test deserialized_f.body isa Expr
 @test deserialized_g(12) == "Serialization with dropped body. y=12"
 @test deserialized_g.body isa Nothing
+
+# deepcopy
+f = @RuntimeGeneratedFunction(:(x -> [x, x+1]))
+@test deepcopy(f) == f
+@test deepcopy(f) === f


### PR DESCRIPTION
This achieves similar behavior to normal Julia functions. Fixes #98.

## Checklist

- [x] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API **(Well, i would say it wasn't explicitly specified before)**
- [x] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC). **(I run the formatter, but the rest of the file does not coply yet. The new code does comply.)**
- [x] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
