### PR TITLE
Bump version to 0.5.17

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RuntimeGeneratedFunctions"
 uuid = "7e49a35a-f44a-4d26-94aa-eba1b4ca6b47"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "0.5.16"
+version = "0.5.17"
 
 [deps]
 ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"


### PR DESCRIPTION
## Version Bump

Bumping version from 0.5.16 to 0.5.17 to prepare for release.

### Changes since last release

- Bump actions/checkout from 4 to 6 (#112)
- Switch from JuliaFormatter to Runic.jl for code formatting (#111)
- Documentation improvements: fix typos and grammar (#110)
- Documentation improvements: fix typo and add docstrings (#109)
- Migrate to Dependabot for dependency management (#108)

**13 total commits** since v0.5.16 (released Oct 31, 2025).

### Registration Command

After merging, register with:

```
@JuliaRegistrator register
```

cc @ChrisRackauckas