### PR TITLE
improve runtime of `expr_to_id`

### DIFF
--- a/src/RuntimeGeneratedFunctions.jl
+++ b/src/RuntimeGeneratedFunctions.jl
@@ -324,10 +324,26 @@ function normalize_args(arg::Expr)
 end
 
 function expr_to_id(ex)
-    io = IOBuffer()
-    Meta.show_sexpr(io, Base.remove_linenums!(deepcopy(ex)))
-    return Tuple(reinterpret(UInt32, sha1(take!(io))))
+    ctx = SHA1_CTX()
+    _hash_expr!(ctx, ex)
+    return Tuple(reinterpret(UInt32, SHA.digest!(ctx)))
 end
+
+_hash_expr!(ctx, ::LineNumberNode) = nothing
+const _OPEN = UInt8['(']
+const _SEP = UInt8[',']
+const _CLOSE = UInt8[')']
+
+function _hash_expr!(ctx, ex::Expr)
+    update!(ctx, _OPEN)
+    update!(ctx, Vector{UInt8}(string(ex.head)))
+    for arg in ex.args
+        update!(ctx, _SEP)
+        _hash_expr!(ctx, arg)
+    end
+    return update!(ctx, _CLOSE)
+end
+_hash_expr!(ctx, ex) = update!(ctx, Vector{UInt8}(string(ex)))
 
 @nospecialize
 
@@ -362,8 +378,10 @@ function closures_to_opaque(ex::Expr, return_type = nothing)
         f_args = Expr(:tuple)
         f_args.args = Any[x.args[1] for x in args[2:end]]
         iters = Any[x.args[2] for x in args[2:end]]
-        new_ex = Expr(:call, GlobalRef(Base, :Generator),
-            closures_to_opaque(Expr(:(->), f_args, args[1])))
+        new_ex = Expr(
+            :call, GlobalRef(Base, :Generator),
+            closures_to_opaque(Expr(:(->), f_args, args[1]))
+        )
         append!(new_ex.args, iters)
         return new_ex
     elseif head === :opaque_closure


### PR DESCRIPTION
I started seeing the `deepcopy` in `expr_to_id`showing up in various profile traces, and since I was the one who added this call in https://github.com/SciML/RuntimeGeneratedFunctions.jl/pull/118 it made me uncomfortable.

This speeds up that part significantly and should still be resilient against the "different sysimage issue" that motivated the original change.

A benchmark where the expression is coming from an `ODEProblem`:

```
# Before
julia> @btime RuntimeGeneratedFunctions.expr_to_id(ex);
  43.599 ms (345134 allocations: 15.09 MiB)

# After

julia> @btime RuntimeGeneratedFunctions.expr_to_id(ex);
  3.764 ms (313062 allocations: 9.79 MiB)
```

This actually has a non-negligible time for the runtime of creating an `ODEProblem` in some cases:

```
# Before
creating ODEProblem: 3.084643 seconds (35.09 M allocations: 1.755 GiB)

# After
creating ODEProblem: 2.491206 seconds (31.82 M allocations: 1.575 GiB)@
```

 Sorry about that.


