### PR TITLE
Centralize CI on SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -11,26 +11,16 @@ on:
     paths-ignore:
       - 'docs/**'
 jobs:
-  test:
-    runs-on: ubuntu-latest
+  downgrade:
+    name: "Downgrade"
     strategy:
+      fail-fast: false
       matrix:
         group:
           - Core
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-#        if: ${{ matrix.version == '1.6' }}
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          ALLOW_RERESOLVE: false
-        env:
-          GROUP: ${{ matrix.group }}
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "1.10"
+      group: "${{ matrix.group }}"
+      skip: "Pkg,TOML"
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,6 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    name: "Runic"
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,6 @@ on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.0 
+    name: "Spell Check with Typos"
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Migrates all CI to the centralized SciML reusable workflows, pinned at `@v1`, each caller passing `secrets: "inherit"`. End-state matches the Sundials.jl reference (Tests, Documentation, Runic, SpellCheck, Downgrade — all via central callers).

## Converted (inline -> central caller)
- **FormatCheck.yml**: inline `fredrikekre/runic-action` -> `runic.yml@v1`.
- **SpellCheck.yml**: inline `crate-ci/typos@v1.18.0` -> `spellcheck.yml@v1`.
- **Downgrade.yml**: inline downgrade job -> `downgrade.yml@v1`, preserving `julia-version: "1.10"`, `group: Core` (matrix), `skip: Pkg,TOML`, and the default `allow-reresolve: false` (was `ALLOW_RERESOLVE: false`).

## Already central (left as-is, already `secrets: "inherit"`)
- **Tests.yml** — `tests.yml@v1`, matrix version [1, lts, pre] x os [ubuntu, macos, windows] preserved.
- **Documentation.yml** — `documentation.yml@v1`.

## Cleanup
- **dependabot.yml**: removed the `crate-ci/typos` ignore (no longer needed since typos is now centralized). `github-actions` (weekly, `/`) and `julia` (daily, group all-julia-packages over `/`, `/docs`, `/test`) blocks preserved.
- No CompatHelper.yml present. TagBot.yml unchanged.
- No Downstream / Benchmark workflows present (none added).

## Checks
- Runic: ran `Runic.main(["--inplace", "."])` — no formatting changes (repo already clean).
- Typos: ran `typos .` — clean (exit 0), 0 fixes.
- All changed YAML validated with `yaml.safe_load`.

## Heads-up
Job/check names change (e.g. the Runic and SpellCheck jobs now come from the reusable callers), so branch-protection required-status-check names will need updating after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)