### PR TITLE
Canonical CI cleanup: TagBot thin-caller + downgrade-caller cleanup

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -20,7 +20,5 @@ jobs:
           - Core
     uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
     with:
-      julia-version: "1.10"
       group: "${{ matrix.group }}"
-      skip: "Pkg,TOML"
     secrets: "inherit"

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,15 +1,9 @@
-name: TagBot
+name: "TagBot"
 on:
   issue_comment:
-    types:
-      - created
+    types: [created]
   workflow_dispatch:
 jobs:
-  TagBot:
-    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: JuliaRegistries/TagBot@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.DOCUMENTER_KEY }}
+  tagbot:
+    uses: "SciML/.github/.github/workflows/tagbot.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
## Canonical CI cleanup

This repo is a single-package (non-monorepo) repo.

**TagBot:** `.github/workflows/TagBot.yml` previously inlined `JuliaRegistries/TagBot` (permissions + steps). Replaced its entire contents with the canonical thin caller `SciML/.github/.github/workflows/tagbot.yml@v1` (single-package form).

**Downgrade caller: removed stdlib-only `skip: "Pkg,TOML"`; pinned julia-version floor to `lts` by deleting the explicit `1.10` (group matrix preserved).**

`Pkg` and `TOML` are Julia stdlibs, so the skip list was entirely stdlib entries; the centralized downgrade workflow now auto-populates the stdlib union, so the input was dropped wholesale. No `[compat]` julia floors were touched.

**.typos.toml:** already present at the repo root, so no SpellCheck/typos starter was added.

Both edited YAML files validated with `yaml.safe_load`.

Ignore until reviewed by @ChrisRackauckas.