### PR TITLE
Canonicalize tests to @safetestset

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,7 @@ BenchmarkTools = "1"
 ExprTools = "0.1"
 Pkg = "1"
 SHA = "0.7, 1"
+SafeTestsets = "0.1, 1"
 Serialization = "1.10"
 Test = "1"
 julia = "1.10"
@@ -22,7 +23,8 @@ julia = "1.10"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "BenchmarkTools", "Pkg", "Test"]
+test = ["Aqua", "BenchmarkTools", "Pkg", "SafeTestsets", "Test"]

--- a/test/core_tests.jl
+++ b/test/core_tests.jl
@@ -1,3 +1,7 @@
+using RuntimeGeneratedFunctions, BenchmarkTools
+using Serialization
+using Test
+
 RuntimeGeneratedFunctions.init(@__MODULE__)
 
 function f(_du, _u, _p, _t)

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 RuntimeGeneratedFunctions = "7e49a35a-f44a-4d26-94aa-eba1b4ca6b47"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
@@ -8,5 +9,6 @@ RuntimeGeneratedFunctions = {path = ".."}
 
 [compat]
 Aqua = "0.8"
+SafeTestsets = "0.1, 1"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,5 +1,7 @@
-using RuntimeGeneratedFunctions, Aqua
-@testset "Aqua" begin
+using SafeTestsets
+
+@safetestset "Aqua" begin
+    using RuntimeGeneratedFunctions, Aqua
     Aqua.find_persistent_tasks_deps(RuntimeGeneratedFunctions)
     Aqua.test_ambiguities(RuntimeGeneratedFunctions, recursive = false)
     Aqua.test_deps_compat(RuntimeGeneratedFunctions)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,12 @@
 using Test
-using RuntimeGeneratedFunctions, BenchmarkTools
-using Serialization
+using SafeTestsets
+using RuntimeGeneratedFunctions
+
+# Serialization resolves an RGF's cache/module tag type by name against the
+# receiving process's `Main`. The serialize round-trip test deserializes an RGF
+# produced by serialize_rgf.jl, which ran `init` in its own `Main`, so `Main`
+# here must also be initialized for that tag to be defined.
+RuntimeGeneratedFunctions.init(@__MODULE__)
 
 const GROUP = get(ENV, "GROUP", "All")
 
@@ -13,5 +19,7 @@ if GROUP == "QA"
 end
 
 if GROUP == "All" || GROUP == "Core"
-    include(joinpath(@__DIR__, "core_tests.jl"))
+    @safetestset "Core" begin
+        include("core_tests.jl")
+    end
 end


### PR DESCRIPTION
## Summary

Wrap each independent test unit in `@safetestset` so it runs in its own module, matching the canonical OrdinaryDiffEq test structure (isolation between tests + world-age safety).

## Changes

- **`test/runtests.jl`**: wrap the Core include in `@safetestset "Core" begin include("core_tests.jl") end`. Moved the `using RuntimeGeneratedFunctions, BenchmarkTools, Serialization` imports out of the shared top scope into the units that use them.
  - Kept `RuntimeGeneratedFunctions.init(@__MODULE__)` at Main top level: the serialize round-trip test (`core_tests.jl`) deserializes an RGF whose module/cache tag type (`#_RGF_ModTag` / `#_RuntimeGeneratedFunctions_cache`) is resolved **by name against the receiving process's `Main`**. `serialize_rgf.jl` ran `init` in its own `Main`, so the parent's `Main` must also be initialized for that tag to exist on deserialize. Without this the Core suite errors with `UndefVarError: #_RGF_ModTag not defined in Main`.
- **`test/core_tests.jl`**: prepend its own `using` lines as top-level statements so the `@RuntimeGeneratedFunction` package macro resolves after the import runs (a `@safetestset` body is macroexpanded as one unit, so an in-body `using` would not take effect before the macro; the `include()` form sidesteps this since the file is parsed statement-by-statement).
- **`test/qa/qa.jl`**: convert the plain `@testset "Aqua"` to `@safetestset` with its own `using RuntimeGeneratedFunctions, Aqua`.
- Add `SafeTestsets` to the root `[extras]`/`[targets].test`/`[compat]` and to `test/qa/Project.toml` (the QA group activates its own env).

The GROUP-dispatch ladder, run logic, and all assertions are unchanged.

## Verification

Verified locally on Julia 1.11:
- `GROUP=Core` → `Core | 31 pass`
- `GROUP=QA` → `Aqua | 10 pass`

Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)