### PR TITLE
Fix QA group [sources] path so develop_sources! resolves repo root

### DIFF
--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -6,7 +6,7 @@ SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
-RuntimeGeneratedFunctions = {path = ".."}
+RuntimeGeneratedFunctions = {path = "../.."}
 
 [compat]
 Aqua = "0.8"


### PR DESCRIPTION
## Problem

Master CI is red: both the `QA` and `Core` grouped-test jobs fail on the LTS (Julia 1.10) with:

```
ERROR: LoadError: could not find project file (Project.toml or JuliaProject.toml)
in package at `.../test/` maybe `subdir` needs to be specified
```

The error originates in `SciMLTesting.develop_sources!` <- `activate_group_env` <- `run_tests` (`test/runtests.jl:9`).

## Root cause

`test/qa/Project.toml` declared the in-repo package source as:

```toml
[sources]
RuntimeGeneratedFunctions = {path = ".."}
```

`[sources]` paths resolve relative to the directory of the `Project.toml` that declares them. The env dir is `test/qa`, so `".."` resolves to `test/` -- which has no `Project.toml`.

This was latent until #129 switched to SciMLTesting v1.2's `run_tests`. Its `activate_group_env` now walks the `[sources]` graph via `develop_sources!` (the Julia 1.10 `[sources]` backport -- a no-op on 1.11+) and `Pkg.develop`s each path, so the bad path now errors. On 1.10 this breaks both the QA group and the Core job.

The env dir `test/qa` is two levels below the repo root, so the path must be `../..` -- matching every other converted SciML repo (e.g. SciMLOperators.jl, SciMLStructures.jl).

## Fix

```diff
 [sources]
-RuntimeGeneratedFunctions = {path = ".."}
+RuntimeGeneratedFunctions = {path = "../.."}
```

## Local verification (Julia 1.10, the LTS)

- Before the fix, `GROUP=QA julia +1.10 -e 'using Pkg; Pkg.test()'` reproduced the CI error exactly.
- After the fix:
  - `GROUP=QA` -> `QA | 10 10` (Aqua passes), `tests passed`.
  - `GROUP=Core` -> `tests passed`.

Please ignore until reviewed by @ChrisRackauckas.
