### PR TITLE
Release prep: bump RuntimeGeneratedFunctions to 0.5.22

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RuntimeGeneratedFunctions"
 uuid = "7e49a35a-f44a-4d26-94aa-eba1b4ca6b47"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "0.5.21"
+version = "0.5.22"
 
 [deps]
 ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"


### PR DESCRIPTION
Patch version bump to 0.5.22 to release the accumulated docstring/QA/test-scaffolding changes (SciMLTesting compat bump and QA doc-rendering check) since 0.5.21.