### PR TITLE
Restore serialization of dropped runtime-generated functions

### DIFF
--- a/src/RuntimeGeneratedFunctions.jl
+++ b/src/RuntimeGeneratedFunctions.jl
@@ -2,7 +2,7 @@ module RuntimeGeneratedFunctions
 
 using ExprTools: ExprTools, combinedef, splitdef
 using SHA: SHA, SHA1_CTX, update!
-using Serialization: Serialization, AbstractSerializer, deserialize
+using Serialization: Serialization, AbstractSerializer, deserialize, serialize
 
 export RuntimeGeneratedFunction, @RuntimeGeneratedFunction, drop_expr
 
@@ -49,10 +49,9 @@ it represents one callable method and does not participate in method dispatch.
 
 # Serialization
 
-`Serialization.serialize` preserves a runtime-generated function while its
-`body` is retained. Serialize a function before calling [`drop_expr`](@ref): a
-dropped function intentionally does not retain the expression needed to restore
-its cache in another process.
+`Serialization.serialize` preserves a runtime-generated function, including
+after [`drop_expr`](@ref). A dropped function's expression is recovered from its
+cache while serializing and remains dropped after deserialization.
 
 # Examples
 
@@ -111,9 +110,6 @@ function callable.
 
 The expression can still be retrieved later using [`get_expression`](@ref) as long
 as at least one `RuntimeGeneratedFunction` with the same body exists.
-
-Serialize a generated function before calling `drop_expr`. A dropped function has
-discarded the expression needed to restore its cache in another process.
 
 # Examples
 ```julia
@@ -509,6 +505,51 @@ function get_expression(
         B,
     }
     return func_expr = Expr(:->, Expr(:tuple, argnames...), _lookup_body(cache_tag, id))
+end
+
+struct _SerializedRuntimeGeneratedFunction{argnames, cache_tag, context_tag, id, B}
+    body::B
+end
+
+function Serialization.serialize(
+        s::AbstractSerializer,
+        ::RuntimeGeneratedFunction{
+            argnames, cache_tag,
+            context_tag, id, Nothing,
+        }
+    ) where {
+        argnames,
+        cache_tag,
+        context_tag,
+        id,
+    }
+    body = _lookup_body(cache_tag, id)
+    proxy = _SerializedRuntimeGeneratedFunction{
+        argnames, cache_tag, context_tag, id, typeof(body),
+    }(body)
+    return serialize(s, proxy)
+end
+
+function Serialization.deserialize(
+        s::AbstractSerializer,
+        ::Type{
+            _SerializedRuntimeGeneratedFunction{
+                argnames, cache_tag,
+                context_tag, id, B,
+            },
+        }
+    ) where {
+        argnames,
+        cache_tag,
+        context_tag,
+        id,
+        B,
+    }
+    body = deserialize(s)
+    cached_body = _cache_body(cache_tag, id, body)
+    return drop_expr(
+        RuntimeGeneratedFunction{argnames, cache_tag, context_tag, id}(cached_body)
+    )
 end
 
 function Serialization.deserialize(

--- a/test/core_tests.jl
+++ b/test/core_tests.jl
@@ -212,14 +212,11 @@ proj = dirname(Base.active_project())
 serialize_script = joinpath(@__DIR__, "shared", "serialize_rgf.jl")
 julia = joinpath(Sys.BINDIR, "julia")
 buf = IOBuffer(read(`$julia --startup-file=no --project=$proj $serialize_script`))
-deserialized_f = deserialize(buf)
+deserialized_f, deserialized_g = deserialize(buf)
 @test deserialized_f(11) == "Hi from a separate process. x=11"
 @test deserialized_f.body isa Expr
-
-serialization_buffer = IOBuffer()
-serialize(serialization_buffer, drop_expr(@RuntimeGeneratedFunction(:(x -> x + 1))))
-seekstart(serialization_buffer)
-@test_throws ArgumentError deserialize(serialization_buffer)
+@test deserialized_g(12) == "Serialization with dropped body. y=12"
+@test deserialized_g.body isa Nothing
 
 # deepcopy
 ff = @RuntimeGeneratedFunction(:(x -> [x, x + 1]))

--- a/test/shared/serialize_rgf.jl
+++ b/test/shared/serialize_rgf.jl
@@ -6,5 +6,6 @@ using Serialization
 RuntimeGeneratedFunctions.init(@__MODULE__)
 
 f = @RuntimeGeneratedFunction(:(x -> "Hi from a separate process. x=$x"))
+g = drop_expr(@RuntimeGeneratedFunction(:(y -> "Serialization with dropped body. y=$y")))
 
-serialize(stdout, f)
+serialize(stdout, (f, g))


### PR DESCRIPTION
Please ignore this PR until reviewed by @ChrisRackauckas.

## Summary

- restore cross-process serialization for `RuntimeGeneratedFunction`s after `drop_expr`
- serialize dropped functions through an internal proxy that carries the cached body, using only the public `Serialization.serialize`/`deserialize` API
- keep the deserialized function dropped while restoring its destination-process cache
- restore the cross-process regression test for both retained and dropped functions

## Root cause

#136 removed the dropped-function serializer while migrating strict QA because it called the non-public `Serialization.serialize_type`. #137 then released that behavioral break as v0.5.23. ModelingToolkitBase has intentionally dropped generated-function bodies since April 2025, so its clean-master distributed test began failing when the worker deserialized an RGF produced in another process. The first bad source commit is `6550973d9290c906b1f61d37d416695e95e63a7c`; v0.5.22 is the passing dependency control.

This implementation avoids the non-public API that motivated the removal.

## Validation

- `julia +1.10 --project=. -e 'using Pkg; Pkg.test()'`
- `julia +1.12 --project=. -e 'using Pkg; Pkg.test()'`
- Runic 1.7.0: `--check --diff .`
- ModelingToolkitBase clean master `d39174937fead779b29fa5baa50ba975adbde8c9`, Julia 1.10, official `GROUP=Extended`:
  - RuntimeGeneratedFunctions v0.5.23: reproduces `ArgumentError: cannot deserialize a dropped RuntimeGeneratedFunction`
  - pinned v0.5.22: passes, including `Distributed Test`
  - this branch developed locally as v0.5.23: passes, including `Distributed Test` and the full Extended group

Downstream failure: SciML/ModelingToolkit.jl#4852.