### PR TITLE
Fix documentation environment compatibility

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -4,4 +4,4 @@ RuntimeGeneratedFunctions = "7e49a35a-f44a-4d26-94aa-eba1b4ca6b47"
 
 [compat]
 Documenter = "1"
-RuntimeGeneratedFunctions = "0.6"
+RuntimeGeneratedFunctions = "0.5"


### PR DESCRIPTION
Please ignore this PR until reviewed by @ChrisRackauckas.

## Summary

Restore the documentation environment's RuntimeGeneratedFunctions compatibility from `0.6` to `0.5`, matching the package's current v0.5.23 version.

## Root cause

#136 moved both the package version and docs compatibility to 0.6. #137 then changed the package back to 0.5.23 but left `docs/Project.toml` requiring 0.6. As a result, the reusable Documentation workflow fails during `Pkg.develop(PackageSpec(path=pwd()))`, before it can build any docs:

```
empty intersection between RuntimeGeneratedFunctions@0.5.23 and project compatibility 0.6
```

An actual Pkg-based git bisect from v0.5.22 (`18e4b5d`) through current master identified #137 (`483e2e938e1bfc5b5df6dc3aab0064c7005d08b6`) as the first bad commit; #136 (`6550973d9290c906b1f61d37d416695e95e63a7c`) is the passing control with both versions at 0.6.

This independent clean-master failure was exposed while auditing #138. It is not caused by that serialization change.

## Validation

Using Julia 1.12.6, matching CI:

- exact reusable-workflow install command now exits 0: `julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'`
- complete local docs build exits 0: `julia --project=docs/ docs/make.jl` (doctests, link checks, document checks, and HTML rendering)
- `julia --project=. -e 'using Pkg; Pkg.test()'`
- Runic 1.7.0: `--check --diff .`

Clean-master failure evidence:

- https://github.com/SciML/RuntimeGeneratedFunctions.jl/actions/runs/30408235778
- same baseline failure on #138: https://github.com/SciML/RuntimeGeneratedFunctions.jl/actions/runs/30521236734