### PR TITLE
Define Base.deepcopy_internal() instead of Base.deepcopy()

### DIFF
--- a/src/RuntimeGeneratedFunctions.jl
+++ b/src/RuntimeGeneratedFunctions.jl
@@ -579,7 +579,7 @@ function Serialization.deserialize(
 end
 
 # Match Julia functions: runtime-generated functions are immutable callable values.
-Base.deepcopy(f::RuntimeGeneratedFunction) = f
+Base.deepcopy_internal(f::RuntimeGeneratedFunction, ::IdDict) = f
 
 @specialize
 

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,3 +1,6 @@
 using RuntimeGeneratedFunctions, SciMLTesting, Test
 
-run_qa(RuntimeGeneratedFunctions)
+run_qa(
+    RuntimeGeneratedFunctions;
+    ei_kwargs = (; all_qualified_accesses_are_public = (; ignore = (:deepcopy_internal,)))
+)


### PR DESCRIPTION
As recommended by the deepcopy() docs. Fixes these invalidations seen when loading CurveFit.jl on 1.13:
```julia
 inserting deepcopy(f::RuntimeGeneratedFunctions.RuntimeGeneratedFunction) @ RuntimeGeneratedFunctions ~/.julia/packages/RuntimeGeneratedFunctions/odmYb/src/RuntimeGeneratedFunctions.jl:582 invalidated:                                     
   backedges: 1: superseding deepcopy(x) @ Base deepcopy.jl:32 with MethodInstance for deepcopy(::Any) (43 children)                                                                                                                           
   1 mt_cache                                                                                                                                                                                                                                  
```

## Checklist

- [ ] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API.