### PR TITLE
Fix multithreaded deadlock between the body cache and the compiler lock

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RuntimeGeneratedFunctions"
 uuid = "7e49a35a-f44a-4d26-94aa-eba1b4ca6b47"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "0.5.24"
+version = "0.5.25"
 
 [deps]
 ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"

--- a/src/RuntimeGeneratedFunctions.jl
+++ b/src/RuntimeGeneratedFunctions.jl
@@ -135,9 +135,9 @@ function drop_expr(
     # GC'd.
     @lock _cache_lock begin
         cache = getfield(parentmodule(cache_tag), _cachename)
-        body = cache[id]
+        body = _cache_getindex(cache, id)
         if body isa WeakRef
-            cache[id] = body.value
+            _cache_setindex!(cache, id, body.value)
         end
     end
     return RuntimeGeneratedFunction{a, cache_tag, c, id}(nothing)
@@ -263,9 +263,57 @@ end
 # little non-robust to weird special cases like Main.eval being
 # Base.MainInclude.eval.)
 
-# It appears we can't use a ReentrantLock here, as contention seems to lead to
-# deadlock. Perhaps because it triggers a task switch while compiling the
-# @generated function.
+# `_lookup_body` runs inside the `generated_callfunc` expansion, i.e. while the
+# calling thread holds Julia's compiler lock, so it must not block: a writer
+# holding `_cache_lock` can itself end up waiting on that compiler lock, since
+# inserting into the cache may compile a specialization. (Yielding instead of
+# blocking is no better, which is why a ReentrantLock deadlocks here too.)
+#
+# Reads are therefore lock-free: the cache is a stack of `Dict`s, newest first,
+# none of which is mutated once published, so a reader takes the stack with one
+# atomic load and probes the levels in order. Writers still serialize on
+# `_cache_lock` and publish a replacement stack.
+#
+# Copying the whole map per insert would be O(n^2) for a package that generates
+# thousands of functions, so a level is merged into the one below it only once
+# it reaches half that level's size (the logarithmic method). Level sizes then
+# more than double going down the stack, bounding both the reader's probes and
+# the entries an insert copies at O(log n).
+mutable struct _BodyCache
+    @atomic levels::Vector{Dict{Any, Any}}
+end
+_BodyCache() = _BodyCache(Dict{Any, Any}[])
+
+struct _NotFound end
+
+function _cache_get(cache::_BodyCache, id)
+    for level in (@atomic :acquire cache.levels)
+        value = get(level, id, _NotFound())
+        value isa _NotFound || return value
+    end
+    return _NotFound()
+end
+
+function _cache_getindex(cache::_BodyCache, id)
+    value = _cache_get(cache, id)
+    value isa _NotFound && throw(KeyError(id))
+    return value
+end
+
+# Caller must hold `_cache_lock`.
+function _cache_setindex!(cache::_BodyCache, id, value)
+    levels = copy(@atomic :monotonic cache.levels)
+    pushfirst!(levels, Dict{Any, Any}(id => value))
+    while length(levels) > 1 && 2 * length(levels[1]) >= length(levels[2])
+        # The newer level wins, so that an updated entry shadows the stale one.
+        merged = merge(levels[2], levels[1])
+        popfirst!(levels)
+        levels[1] = merged
+    end
+    @atomic :release cache.levels = levels
+    return value
+end
+
 _cache_lock = Threads.SpinLock()
 _cachename = Symbol("#_RuntimeGeneratedFunctions_cache")
 _tagname = Symbol("#_RGF_ModTag")
@@ -285,29 +333,27 @@ function _cache_body(cache_tag, id, body)
         # can collect it (causing it to become `nothing`). So root it in a
         # local variable first.
         #
-        cached_body = get(cache, id, nothing)
-        if !isnothing(cached_body)
-            if cached_body isa WeakRef
-                # `value` may be nothing here if it was previously cached but GC'd
-                cached_body = cached_body.value
-            end
+        cached_body = _cache_get(cache, id)
+        if cached_body isa _NotFound
+            cached_body = nothing
+        elseif cached_body isa WeakRef
+            # `value` may be nothing here if it was previously cached but GC'd
+            cached_body = cached_body.value
         end
         if isnothing(cached_body)
             cached_body = body
             # Use a WeakRef to allow `body` to be garbage collected. (After GC, the
             # cache will still contain an empty entry with key `id`.)
-            cache[id] = WeakRef(cached_body)
+            _cache_setindex!(cache, id, WeakRef(cached_body))
         end
         return cached_body
     end
 end
 
 function _lookup_body(cache_tag, id)
-    return lock(_cache_lock) do
-        cache = getfield(parentmodule(cache_tag), _cachename)
-        body = cache[id]
-        body isa WeakRef ? body.value : body
-    end
+    cache = getfield(parentmodule(cache_tag), _cachename)
+    body = _cache_getindex(cache, id)
+    return body isa WeakRef ? body.value : body
 end
 
 """
@@ -342,7 +388,7 @@ function init(mod)
         if !isdefined(mod, _cachename)
             mod.eval(
                 quote
-                    const $_cachename = Dict()
+                    const $_cachename = $RuntimeGeneratedFunctions._BodyCache()
                     struct $_tagname end
 
                     # We create method of `generated_callfunc` in the user's module

--- a/test/core_tests.jl
+++ b/test/core_tests.jl
@@ -4,6 +4,10 @@ using Serialization
 
 RuntimeGeneratedFunctions.init(@__MODULE__)
 
+# Used by the tests that run a script in a fresh process.
+proj = dirname(Base.active_project())
+julia = joinpath(Sys.BINDIR, "julia")
+
 function f(_du, _u, _p, _t)
     @inbounds _du[1] = _u[1]
     @inbounds _du[2] = _u[2]
@@ -129,33 +133,20 @@ GC.gc()
 @test f_drop1(1) == 0
 @test f_drop2(1) == 0
 
-# Test that threaded use works
-tasks = []
-for k in 1:4
-    let k = k
-        t = Threads.@spawn begin
-            r = Bool[]
-            for i in 1:100
-                f = @RuntimeGeneratedFunction(
-                    Base.remove_linenums!(
-                        :(
-                            (
-                                x, y,
-                            ) -> x + y +
-                                $i * $k
-                        )
-                    )
-                )
-                x = 1
-                y = 2
-                push!(r, f(x, y) == x + y + i * k)
-            end
-            r
-        end
-        push!(tasks, t)
+# Test that threaded use works. Cache reads happen while the caller holds
+# Julia's compiler lock, so a cache that blocks there deadlocks instead of
+# failing; the subprocess needs a watchdog and more than one thread.
+let
+    script = joinpath(@__DIR__, "shared", "threaded_rgf.jl")
+    proc = run(`$julia --startup-file=no --project=$proj --threads=8 $script`; wait = false)
+    watchdog = Timer(_ -> process_running(proc) && kill(proc, Base.SIGKILL), 600)
+    try
+        wait(proc)
+    finally
+        close(watchdog)
     end
+    @test success(proc)
 end
-@test all(all.(fetch.(tasks)))
 
 # Test that globals are resolved within the correct scope
 
@@ -208,9 +199,7 @@ ex = :(x -> [2i for i in 1:x])
 
 # Serialization
 
-proj = dirname(Base.active_project())
 serialize_script = joinpath(@__DIR__, "shared", "serialize_rgf.jl")
-julia = joinpath(Sys.BINDIR, "julia")
 buf = IOBuffer(read(`$julia --startup-file=no --project=$proj $serialize_script`))
 deserialized_f, deserialized_g = deserialize(buf)
 @test deserialized_f(11) == "Hi from a separate process. x=11"

--- a/test/shared/threaded_rgf.jl
+++ b/test/shared/threaded_rgf.jl
@@ -1,0 +1,19 @@
+# Construct and call RuntimeGeneratedFunctions from several threads at once.
+# Run as a subprocess by core_tests.jl because the failure mode it guards
+# against is a hang rather than a wrong answer, and it needs more than one
+# thread to show up.
+
+using RuntimeGeneratedFunctions
+RuntimeGeneratedFunctions.init(@__MODULE__)
+
+tasks = map(1:max(4, Threads.nthreads())) do k
+    Threads.@spawn begin
+        for i in 1:100
+            f = @RuntimeGeneratedFunction(
+                Base.remove_linenums!(:((x, y) -> x + y + $i * $k))
+            )
+            f(1, 2) == 3 + i * k || error("wrong result for i=$i, k=$k")
+        end
+    end
+end
+foreach(fetch, tasks)


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

Fixes https://github.com/SciML/RuntimeGeneratedFunctions.jl/issues/141.

## What changed and why

`_lookup_body` is called from the expansion of the `generated_callfunc`
`@generated` method, so it runs while the calling thread holds Julia's compiler
lock — and it took `_cache_lock`. Meanwhile `_cache_body` holds `_cache_lock`
while inserting into the cache `Dict`, and that insert can compile a
specialization (`setindex!` → `rehash!` → codegen) and block on the compiler
lock. Classic lock-order inversion; because `_cache_lock` is a `SpinLock`, the
hung threads sit at 100% CPU.

Reads are now lock-free. The cache is a stack of `Dict`s, newest first, none of
which is mutated once published; a reader takes the stack with a single atomic
load. Writers still serialize on `_cache_lock` and publish a replacement stack.
Copying the whole map per insert would be O(n²) for a package that generates
thousands of functions, so levels merge on the logarithmic method (a level merges
down once it reaches half the next level's size): sizes more than double going
down the stack, bounding both a reader's probes and an insert's copying at
O(log n).

The cache object stored in each initialized module changes from `Dict()` to an
internal `RuntimeGeneratedFunctions._BodyCache`. That name
(`#_RuntimeGeneratedFunctions_cache`) is not public API, but it is a shape change
for anything reaching into it.

## Failing before / passing after

Reproducer from the issue, on Julia 1.10.11 (also reproduces on 1.13.0-rc3):

Before (`master`, `--threads=8`, `timeout -s KILL 90`; exit 137 = killed while hung):

```
--- run 1
[2179500] signal (15): Terminated
...
lock at ./locks-mt.jl:48
_lookup_body at src/RuntimeGeneratedFunctions.jl:306      <-- spins on _cache_lock
generated_callfunc_body at src/RuntimeGeneratedFunctions.jl:243
#s1#1 at src/RuntimeGeneratedFunctions.jl:372 [inlined]
jl_type_infer at src/gf.c:396                             <-- holds the compiler lock
...
_jl_mutex_wait at src/threading.c:857                     <-- waits for the compiler lock
jl_generate_fptr_impl at src/jitlayers.cpp:483
rehash! at ./dict.jl:194
setindex! at ./dict.jl:399
#6 at src/RuntimeGeneratedFunctions.jl:299                 <-- holds _cache_lock
_cache_body at src/RuntimeGeneratedFunctions.jl:274
```

After (same command, 5 consecutive runs):

```
OK
run 1 exit=0
OK
run 2 exit=0
OK
run 3 exit=0
OK
run 4 exit=0
OK
run 5 exit=0
```

## The regression test discriminates

The existing threaded test ran in-process, and the suite runs single-threaded, so
it never exercised this. It now runs `test/shared/threaded_rgf.jl` in a
subprocess with `--threads=8` and a 600 s watchdog.

With the fix reverted (`git stash push src/RuntimeGeneratedFunctions.jl`) and the
new test in place, `include("test/core_tests.jl")` on Julia 1.10:

```
Test Failed at test/core_tests.jl:148
  Expression: success(proc)

ERROR: LoadError: There was an error during testing
```

CI Core also runs on macOS and Windows; to check it discriminates on a
low-core-count runner, `taskset -c 0,1` (2 cores) on the unfixed code hangs 3/3
at `--threads=8` and 3/3 at `--threads=2`, and passes 3/3 at both with the fix.

## Verification

Run locally on this branch:

```
$ GROUP=Core  julia +1.10 --project -e 'using Pkg; Pkg.test()'   -> tests passed
$ GROUP=QA    julia +1.10 --project -e 'using Pkg; Pkg.test()'   -> QA | 18  18  18.9s, tests passed
$ GROUP=Core  julia +1.12 --project -e 'using Pkg; Pkg.test()'   -> tests passed
$ GROUP=QA    julia +1.12 --project -e 'using Pkg; Pkg.test()'   -> QA | 20  20  25.0s, tests passed
$ GROUP=Core  julia +1.11 --project -e 'using Pkg; Pkg.test()'   -> tests passed
$ GROUP=QA    julia +1.11 --project -e 'using Pkg; Pkg.test()'   -> QA | 20  20  26.6s, tests passed
$ GROUP=Core  julia +rc   --project -e 'using Pkg; Pkg.test()'   -> tests passed   (1.13.0-rc3)
$ GROUP=QA    julia +rc   --project -e 'using Pkg; Pkg.test()'   -> QA | 20  20  20.8s, tests passed
$ julia --project=docs docs/make.jl                              -> builds clean
$ Runic.main(["--check", "--diff", "src", "test", "docs"])       -> clean
$ typos src test docs README.md                                  -> clean
```

## Performance

The cost is on inserts. Cache-only microbenchmark (`_cache_body` on n distinct
ids, then `_lookup_body` on each), Julia 1.10:

| n | insert (master) | insert (this PR) | lookup (master) | lookup (this PR) |
|---|---|---|---|---|
| 10,000 | 0.019 s | 0.041 s | 0.005 s | 0.005 s |
| 50,000 | 0.056 s | 0.202 s | 0.035 s | 0.021 s |
| 100,000 | 0.085 s | 0.492 s | 0.068 s | 0.062 s |

Scaling is n log n, not n²: 10× the entries costs 12× the time. End-to-end
`RuntimeGeneratedFunction` construction (which is dominated by SHA-1 hashing the
expression, and in real use by codegen):

| n | master | this PR |
|---|---|---|
| 10,000 | 0.199 s | 0.216 s |
| 50,000 | 0.945 s | 1.088 s |

## CI

All 16 checks green: Core on {ubuntu, macOS, Windows} × {lts, 1, pre}, QA, Downgrade,
Documentation, Runic, typos. My local runs were Linux-only, so CI is what covers the
new subprocess test's `kill(proc, Base.SIGKILL)` watchdog on macOS and Windows.

## Not verified

- Downstream packages (ModelingToolkit, Symbolics, …) were not run against this.
- Non-x86 architectures. The atomics are `:acquire`/`:release` rather than
  relying on x86 store ordering, so this should be fine, but it was not tested.

## Worth pushing back on

- Writers still use `Threads.SpinLock`. Now that readers never take it, a
  `ReentrantLock` would be safe and would stop other writers burning cores while
  one of them compiles under the lock. I left it alone to keep the diff to the
  deadlock, but it is a reasonable follow-up.
- Version bumped 0.5.24 → 0.5.25. The internal per-module cache object type
  changes, which is a patch-level change only because that name is not public
  API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9uAJ7kQsHJtp7Yb2qdFVV
