### PR TITLE
Avoid specializing drop_expr on concrete RGF types

### DIFF
--- a/src/RuntimeGeneratedFunctions.jl
+++ b/src/RuntimeGeneratedFunctions.jl
@@ -91,6 +91,11 @@ struct RuntimeGeneratedFunction{argnames, cache_tag, context_tag, id, B} <: Func
     end
 end
 
+_argnames(::RuntimeGeneratedFunction{a}) where {a} = a
+_cache_tag(::RuntimeGeneratedFunction{a, ct}) where {a, ct} = ct
+_context_tag(::RuntimeGeneratedFunction{a, ct, cx}) where {a, ct, cx} = cx
+_id(::RuntimeGeneratedFunction{a, ct, cx, id}) where {a, ct, cx, id} = id
+
 """
     drop_expr(rgf::RuntimeGeneratedFunction)
 
@@ -119,28 +124,19 @@ rgf_dropped = drop_expr(rgf)
 rgf_dropped(2)  # Still works, returns 4
 ```
 """
-function drop_expr(
-        ::RuntimeGeneratedFunction{
-            a,
-            cache_tag,
-            c,
-            id,
-        }
-    ) where {
-        a, cache_tag, c,
-        id,
-    }
+function drop_expr(@nospecialize(rgf::RuntimeGeneratedFunction))
     # When dropping the reference to the body from an RGF, we need to upgrade
     # from a weak to a strong reference in the cache to prevent the body being
     # GC'd.
+    a, ct, cx, id = _argnames(rgf), _cache_tag(rgf), _context_tag(rgf), _id(rgf)
     @lock _cache_lock begin
-        cache = getfield(parentmodule(cache_tag), _cachename)
+        cache = getfield(parentmodule(ct), _cachename)
         body = _cache_getindex(cache, id)
         if body isa WeakRef
             _cache_setindex!(cache, id, body.value)
         end
     end
-    return RuntimeGeneratedFunction{a, cache_tag, c, id}(nothing)
+    return RuntimeGeneratedFunction{a, ct, cx, id}(nothing)
 end
 
 function _check_rgf_initialized(mods...)

--- a/test/core_tests.jl
+++ b/test/core_tests.jl
@@ -133,6 +133,23 @@ GC.gc()
 @test f_drop1(1) == 0
 @test f_drop2(1) == 0
 
+let
+    script = joinpath(@__DIR__, "shared", "drop_expr_specializations.jl")
+    trace_file, trace_io = mktemp()
+    close(trace_io)
+    try
+        run(`$julia --startup-file=no --project=$proj --trace-compile=$trace_file $script`)
+        specializations = count(eachline(trace_file)) do line
+            startswith(
+                line, "precompile(Tuple{typeof(RuntimeGeneratedFunctions.drop_expr),"
+            )
+        end
+        @test specializations == 0
+    finally
+        rm(trace_file; force = true)
+    end
+end
+
 # Test that threaded use works. Cache reads happen while the caller holds
 # Julia's compiler lock, so a cache that blocks there deadlocks instead of
 # failing; the subprocess needs a watchdog and more than one thread.

--- a/test/shared/drop_expr_specializations.jl
+++ b/test/shared/drop_expr_specializations.jl
@@ -1,0 +1,5 @@
+using RuntimeGeneratedFunctions
+
+RuntimeGeneratedFunctions.init(@__MODULE__)
+functions = [@RuntimeGeneratedFunction(:(x -> x + $i)) for i in 1:20]
+foreach(drop_expr, functions)


### PR DESCRIPTION
## What changed and why

This supersedes https://github.com/SciML/RuntimeGeneratedFunctions.jl/pull/123, whose contributor-fork head cannot be updated by the currently authenticated account. The commit retains Kristoffer Carlsson as author.

`drop_expr` previously specialized on every concrete `RuntimeGeneratedFunction` type, including its expression ID, compiling a new method instance for each generated function. This adds a specialization barrier, extracts the required type parameters through small helpers, and preserves the current thread-safe `_BodyCache` accessors.

## Regression evidence

Unfixed `master`, with the new test applied:

```text
env GROUP=Core timeout 3600 julia +1.10 --startup-file=no --project=. -e "using Pkg; Pkg.test()"
Test Failed at test/core_tests.jl:147
  Expression: specializations == 0
   Evaluated: 20 == 0
```

The same command with this fix:

```text
Testing RuntimeGeneratedFunctions tests passed
```

## Verification

```text
GROUP=Core julia +1.10 --project=. -e "using Pkg; Pkg.test()"
Testing RuntimeGeneratedFunctions tests passed

GROUP=Core julia +release --project=. -e "using Pkg; Pkg.test()"
Testing RuntimeGeneratedFunctions tests passed

GROUP=Core julia +1.13 --project=. -e "using Pkg; Pkg.test()"
Testing RuntimeGeneratedFunctions tests passed

GROUP=QA julia +1.10 --project=. -e "using Pkg; Pkg.test()"
QA | 18 passed / 18 total

GROUP=QA julia +release --project=. -e "using Pkg; Pkg.test()"
QA | 20 passed / 20 total

julia +release --project=docs docs/make.jl
Documenter completed doctests, document checks, link checks, and HTML rendering successfully.

julia +release --project=<Runic package> -m Runic --check --diff .
No output; exit status 0.

typos src/RuntimeGeneratedFunctions.jl test/core_tests.jl test/shared/drop_expr_specializations.jl
No output; exit status 0.
```

## Not verified locally

- macOS and Windows runners
- 32-bit Julia

## Reviewer judgment call

The regression test uses Julias documented `--trace-compile` CLI output in a fresh subprocess and asserts that calls over 20 distinct RGF types emit no concrete `drop_expr` precompile statements. This directly detects the compilation blow-up without relying on private compiler-introspection APIs.

Ignore this PR until it has been reviewed by @ChrisRackauckas.