### PR TITLE
Add PrecompileTools workload

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,12 +5,14 @@ version = "0.5.25"
 
 [deps]
 ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
 [compat]
 BenchmarkTools = "1"
 ExprTools = "0.1"
+PrecompileTools = "1.2"
 SHA = "0.7, 1"
 SafeTestsets = "0.1, 1"
 SciMLTesting = "2.4"

--- a/src/RuntimeGeneratedFunctions.jl
+++ b/src/RuntimeGeneratedFunctions.jl
@@ -625,4 +625,16 @@ Base.deepcopy_internal(f::RuntimeGeneratedFunction, ::IdDict) = f
 
 @specialize
 
+using PrecompileTools: @compile_workload, @setup_workload
+
+@setup_workload begin
+    init(@__MODULE__)
+    @compile_workload begin
+        increment = RuntimeGeneratedFunction(@__MODULE__, @__MODULE__, :(x -> x + 1))
+        increment(41)
+        get_expression(increment)
+        drop_expr(increment)
+    end
+end
+
 end


### PR DESCRIPTION
## Summary
Adds a PrecompileTools workload covering representative public APIs so the package common execution path is compiled during precompilation.

## Verification
The branch was validated locally with package load/precompile, a focused workload smoke test, and repository checks where available. Runic, typos, and git diff --check were checked for the change.

## Known limitations
No additional limitation was observed in the focused verification.

This draft should be ignored until reviewed by @ChrisRackauckas.