### PR TITLE
Gensym / remove the RGF name instead of using `f` and `__args`

### DIFF
--- a/src/RuntimeGeneratedFunctions.jl
+++ b/src/RuntimeGeneratedFunctions.jl
@@ -234,16 +234,6 @@ end
 # @RuntimeGeneratedFunction
 function generated_callfunc end
 
-function generated_callfunc_body(argnames, cache_tag, id, __args)
-    setup = (:($(argnames[i]) = @inbounds __args[$i]) for i in 1:length(argnames))
-    body = _lookup_body(cache_tag, id)
-    @assert body !== nothing
-    return quote
-        $(setup...)
-        $(body)
-    end
-end
-
 ### Body caching and lookup
 #
 # Looking up the body of a RuntimeGeneratedFunction based on the id is a little
@@ -382,6 +372,7 @@ end
 function init(mod)
     return lock(_cache_lock) do
         if !isdefined(mod, _cachename)
+            @gensym args
             mod.eval(
                 quote
                     const $_cachename = $RuntimeGeneratedFunctions._BodyCache()
@@ -405,17 +396,20 @@ function init(mod)
                                 $_tagname,
                                 id,
                             },
-                            __args...
+                            $(args)...
                         ) where {
                             argnames,
                             cache_tag,
                             id,
                         }
-                        return $RuntimeGeneratedFunctions.generated_callfunc_body(
-                            argnames,
-                            cache_tag,
-                            id, __args
-                        )
+                        args_sym = $(QuoteNode(args))
+                        setup = (:($(argnames[i]) = @inbounds $(args_sym)[$i]) for i in 1:length(argnames))
+                        body = $RuntimeGeneratedFunctions._lookup_body(cache_tag, id)
+                        @assert body !== nothing
+                        return quote
+                            $(setup...)
+                            $(body)
+                        end
                     end
                 end
             )

--- a/src/RuntimeGeneratedFunctions.jl
+++ b/src/RuntimeGeneratedFunctions.jl
@@ -234,6 +234,16 @@ end
 # @RuntimeGeneratedFunction
 function generated_callfunc end
 
+function generated_callfunc_body(argnames, cache_tag, id, __args)
+    setup = (:($(argnames[i]) = @inbounds __args[$i]) for i in 1:length(argnames))
+    body = _lookup_body(cache_tag, id)
+    @assert body !== nothing
+    return quote
+        $(setup...)
+        $(body)
+    end
+end
+
 ### Body caching and lookup
 #
 # Looking up the body of a RuntimeGeneratedFunction based on the id is a little
@@ -372,7 +382,6 @@ end
 function init(mod)
     return lock(_cache_lock) do
         if !isdefined(mod, _cachename)
-            @gensym args
             mod.eval(
                 quote
                     const $_cachename = $RuntimeGeneratedFunctions._BodyCache()
@@ -396,20 +405,17 @@ function init(mod)
                                 $_tagname,
                                 id,
                             },
-                            $(args)...
+                            __args...
                         ) where {
                             argnames,
                             cache_tag,
                             id,
                         }
-                        args_sym = $(QuoteNode(args))
-                        setup = (:($(argnames[i]) = @inbounds $(args_sym)[$i]) for i in 1:length(argnames))
-                        body = $RuntimeGeneratedFunctions._lookup_body(cache_tag, id)
-                        @assert body !== nothing
-                        return quote
-                            $(setup...)
-                            $(body)
-                        end
+                        return $RuntimeGeneratedFunctions.generated_callfunc_body(
+                            argnames,
+                            cache_tag,
+                            id, __args
+                        )
                     end
                 end
             )

--- a/src/RuntimeGeneratedFunctions.jl
+++ b/src/RuntimeGeneratedFunctions.jl
@@ -399,7 +399,7 @@ function init(mod)
                     #   https://github.com/JuliaLang/julia/pull/32902
                     #   https://github.com/NHDaly/StagedFunctions.jl/blob/master/src/StagedFunctions.jl#L30
                     @inline @generated function $RuntimeGeneratedFunctions.generated_callfunc(
-                            f::$RuntimeGeneratedFunctions.RuntimeGeneratedFunction{
+                            ::$RuntimeGeneratedFunctions.RuntimeGeneratedFunction{
                                 argnames,
                                 cache_tag,
                                 $_tagname,

--- a/test/core_tests.jl
+++ b/test/core_tests.jl
@@ -191,10 +191,13 @@ f_outside = @RuntimeGeneratedFunction(GlobalsTest, :(x -> x + y_in_GlobalsTest))
 ex = :(x -> (y -> x + y))
 @test @RuntimeGeneratedFunction(ex)(2)(3) === 5
 
-# used to stack overflow due to RGF calling itself, #146
+# used to stack overflow / error due to RGF calling itself, #146
 f(x) = x + 1
 ex = :(function(x); f(x); end)
 @test @RuntimeGeneratedFunction(ex)(3) === 4
+__args(x) = x + 2
+ex = :(function(x); __args(x); end)
+@test @RuntimeGeneratedFunction(ex)(3) === 5
 
 ex = :(x -> (f(y::Int)::Float64 = x + y; f))
 @test @RuntimeGeneratedFunction(ex)(2)(3) === 5.0

--- a/test/core_tests.jl
+++ b/test/core_tests.jl
@@ -193,7 +193,11 @@ ex = :(x -> (y -> x + y))
 
 # used to stack overflow due to RGF calling itself, #146
 f(x) = x + 1
-ex = :(function(x); f(x); end)
+ex = :(
+    function (x)
+        return f(x)
+    end
+)
 @test @RuntimeGeneratedFunction(ex)(3) === 4
 
 ex = :(x -> (f(y::Int)::Float64 = x + y; f))

--- a/test/core_tests.jl
+++ b/test/core_tests.jl
@@ -191,6 +191,11 @@ f_outside = @RuntimeGeneratedFunction(GlobalsTest, :(x -> x + y_in_GlobalsTest))
 ex = :(x -> (y -> x + y))
 @test @RuntimeGeneratedFunction(ex)(2)(3) === 5
 
+# used to stack overflow due to RGF calling itself, #146
+f(x) = x + 1
+ex = :(function(x); f(x); end)
+@test @RuntimeGeneratedFunction(ex)(3) === 4
+
 ex = :(x -> (f(y::Int)::Float64 = x + y; f))
 @test @RuntimeGeneratedFunction(ex)(2)(3) === 5.0
 

--- a/test/core_tests.jl
+++ b/test/core_tests.jl
@@ -191,13 +191,10 @@ f_outside = @RuntimeGeneratedFunction(GlobalsTest, :(x -> x + y_in_GlobalsTest))
 ex = :(x -> (y -> x + y))
 @test @RuntimeGeneratedFunction(ex)(2)(3) === 5
 
-# used to stack overflow / error due to RGF calling itself, #146
+# used to stack overflow due to RGF calling itself, #146
 f(x) = x + 1
 ex = :(function(x); f(x); end)
 @test @RuntimeGeneratedFunction(ex)(3) === 4
-__args(x) = x + 2
-ex = :(function(x); __args(x); end)
-@test @RuntimeGeneratedFunction(ex)(3) === 5
 
 ex = :(x -> (f(y::Int)::Float64 = x + y; f))
 @test @RuntimeGeneratedFunction(ex)(2)(3) === 5.0


### PR DESCRIPTION
Closes #146. `f` was not needed so that could just be removed.

For `__args` the chance of collision is quite small but it's obviously an improvement to gensym it. It was quite annoying to pass a gensym'd `args` into the `generated_callfunc_body`, so I just inlined that function.

The newly added tests fail on current master and pass with this PR!